### PR TITLE
Add thread timeout

### DIFF
--- a/anti-behavioral-analysis/evade-debugger.md
+++ b/anti-behavioral-analysis/evade-debugger.md
@@ -42,6 +42,7 @@ Methods
 * **Static Linking**: Copy locally the whole content of API code.
 * **Stolen API Code**: A variation of “byte stealing” where the first few instructions or bytes of an API are executed in user code, allowing the IAT to point into the middle of an API function. This confuses IAT rebuilders such as ImpRec and Scylla and may bypass breakpoints.
 * **Tampering**: Erase or corrupt specific file parts to prevent rebuilding (header, packer stub, etc.).
+* **Thread Timeout**: Setting dwMilliseconds in WaitForSingleObject to a small number will timeout the thread before the analyst can step through and analyze the code executing in the thread. Modifying this via patch, register, or stack to the value `0xFFFFFFFF`, the **INFINITE** constant circumvents this anti-debugging technique.
 * **TIB Aware**: Accessing thread information (fs:[20h]) for debug detection or process obfuscation.
 * **Use Interrupts**: The unpacking code relies on use of int 1 or int 3, or it uses the interrupt vector table as part of the decryption “key”.
 


### PR DESCRIPTION
This is used by Sodinokibi version 102. In Sodinokibi's Heaven's Gate shellcode, the exploit code is run in a thread with a very short timeout.